### PR TITLE
chore: set up global `Cargo.toml` with workspaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@
 *.toc
 *.out
 *.pdf
+
+
+# Added by cargo
+/target

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "rustar-gs"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+
+[workspace]
+members = []


### PR DESCRIPTION
Set up global `Cargo.toml` with workspaces, and `.gitignore`.