### PR TITLE
Fix Cargo workspace setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,6 @@
 *.out
 *.pdf
 
-
 # Added by cargo
-/target
+**/target
+**/Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,2 @@
-[package]
-name = "rustar-gs"
-version = "0.1.0"
-edition = "2024"
-
-[dependencies]
-
 [workspace]
 members = []


### PR DESCRIPTION
Cleans root `Cargo.toml` and updates `.gitignore`.