### PR TITLE
Satellite position prediction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
-members = []
+members = ["tracking"]
+resolver = "3"

--- a/tracking/Cargo.toml
+++ b/tracking/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "tracking"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+predict-rs = "0.1.1"
+sgp4 = "2.3.0"

--- a/tracking/examples/iss.rs
+++ b/tracking/examples/iss.rs
@@ -1,0 +1,28 @@
+use predict_rs::{consts::DEG_TO_RAD, predict::PredictObserver};
+use sgp4::chrono;
+use tracking::{self, Tracker};
+
+fn main() {
+    let elements = sgp4::Elements::from_tle(
+        Some("ISS (ZARYA)".to_owned()),
+        "1 25544U 98067A   25186.50618345  .00006730  00000+0  12412-3 0  9992".as_bytes(),
+        "2 25544  51.6343 216.2777 0002492 336.9059  23.1817 15.50384048518002".as_bytes(),
+    )
+    .unwrap();
+
+    let buenos_aires = PredictObserver {
+        name: "Buenos Aires".to_string(),
+        latitude: -34.6 * DEG_TO_RAD,
+        longitude: -58.4 * DEG_TO_RAD,
+        altitude: 2.5,
+        min_elevation: 0.0,
+    };
+
+    let tracker = Tracker::new(&buenos_aires, &elements).unwrap();
+
+    let now = chrono::Utc::now().timestamp();
+
+    let observation = tracker.track(now).unwrap();
+
+    println!("{:?}", observation);
+}

--- a/tracking/examples/iss.rs
+++ b/tracking/examples/iss.rs
@@ -1,6 +1,5 @@
-use predict_rs::{consts::DEG_TO_RAD, predict::PredictObserver};
 use sgp4::chrono;
-use tracking::{self, Tracker};
+use tracking::{Observer, Tracker};
 
 fn main() {
     let elements = sgp4::Elements::from_tle(
@@ -10,13 +9,7 @@ fn main() {
     )
     .unwrap();
 
-    let buenos_aires = PredictObserver {
-        name: "Buenos Aires".to_string(),
-        latitude: -34.6 * DEG_TO_RAD,
-        longitude: -58.4 * DEG_TO_RAD,
-        altitude: 2.5,
-        min_elevation: 0.0,
-    };
+    let buenos_aires = Observer::new(-34.6, -58.4, 2.5);
 
     let tracker = Tracker::new(&buenos_aires, &elements).unwrap();
 

--- a/tracking/src/lib.rs
+++ b/tracking/src/lib.rs
@@ -1,0 +1,41 @@
+use predict_rs::{
+    observer, orbit,
+    predict::{self, PredictObservation},
+};
+
+#[derive(Debug)]
+pub enum TrackerError {
+    ElementsError(sgp4::ElementsError),
+    OrbitPredictionError(orbit::OrbitPredictionError),
+}
+
+pub struct Tracker<'a> {
+    observer: &'a predict::PredictObserver,
+    elements: &'a sgp4::Elements,
+    constants: sgp4::Constants,
+}
+
+impl<'a> Tracker<'a> {
+    pub fn new(
+        observer: &'a predict::PredictObserver,
+        elements: &'a sgp4::Elements,
+    ) -> Result<Self, TrackerError> {
+        let constants = sgp4::Constants::from_elements(elements)
+            .map_err(|err| TrackerError::ElementsError(err))?;
+
+        Ok(Self {
+            observer,
+            elements,
+            constants,
+        })
+    }
+
+    pub fn track(&self, at: i64) -> Result<PredictObservation, TrackerError> {
+        let orbit = orbit::predict_orbit(self.elements, &self.constants, at as f64)
+            .map_err(|err| TrackerError::OrbitPredictionError(err))?;
+
+        let observation = observer::predict_observe_orbit(self.observer, &orbit);
+
+        Ok(observation)
+    }
+}

--- a/tracking/src/lib.rs
+++ b/tracking/src/lib.rs
@@ -1,7 +1,13 @@
-use predict_rs::{
-    observer, orbit,
-    predict::{self, PredictObservation},
-};
+use predict_rs::{consts::RAD_TO_DEG, observer, orbit, predict};
+
+/// The predicted observation.
+#[derive(Debug)]
+pub struct Observation {
+    /// Azimuth, in degrees.
+    pub azimuth: f64,
+    /// Elevation, in degrees.
+    pub elevation: f64,
+}
 
 #[derive(Debug)]
 pub enum TrackerError {
@@ -30,12 +36,15 @@ impl<'a> Tracker<'a> {
         })
     }
 
-    pub fn track(&self, at: i64) -> Result<PredictObservation, TrackerError> {
+    pub fn track(&self, at: i64) -> Result<Observation, TrackerError> {
         let orbit = orbit::predict_orbit(self.elements, &self.constants, at as f64)
             .map_err(|err| TrackerError::OrbitPredictionError(err))?;
 
         let observation = observer::predict_observe_orbit(self.observer, &orbit);
 
-        Ok(observation)
+        Ok(Observation {
+            azimuth: observation.azimuth * RAD_TO_DEG,
+            elevation: observation.elevation * RAD_TO_DEG,
+        })
     }
 }

--- a/tracking/src/lib.rs
+++ b/tracking/src/lib.rs
@@ -49,8 +49,8 @@ pub struct Tracker<'a> {
 
 impl<'a> Tracker<'a> {
     pub fn new(observer: &Observer, elements: &'a sgp4::Elements) -> Result<Self, TrackerError> {
-        let constants = sgp4::Constants::from_elements(elements)
-            .map_err(|err| TrackerError::ElementsError(err))?;
+        let constants =
+            sgp4::Constants::from_elements(elements).map_err(TrackerError::ElementsError)?;
 
         let observer = PredictObserver {
             name: "".to_string(),
@@ -69,7 +69,7 @@ impl<'a> Tracker<'a> {
 
     pub fn track(&self, at: i64) -> Result<Observation, TrackerError> {
         let orbit = orbit::predict_orbit(self.elements, &self.constants, at as f64)
-            .map_err(|err| TrackerError::OrbitPredictionError(err))?;
+            .map_err(TrackerError::OrbitPredictionError)?;
 
         let observation = observer::predict_observe_orbit(&self.observer, &orbit);
 


### PR DESCRIPTION
This PR implements the satellite position prediction, given a TLE and a timestamp, using the `predict-rs` crate.

Next steps include:
- Get Doppler correction frequencies for uplink and downlink, given the range rate (speed relative to the observer) obtained during the prediction.
- Maybe predict next satellite passes in a given future timeframe.
- Improve testing with a comprehensive test suite. It's been tested against the results obtained in Orbitron and Gpredict, but we could provide a test suite to be run in the CI pipeline.