### PR TITLE
[telemetry] feat: define `TelemetryRecord` struct with `serde`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,6 @@ members = [
     "ground-station",
     "framing",
     "demod",
+    "telemetry",
 ]
 resolver = "3"

--- a/telemetry/Cargo.toml
+++ b/telemetry/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "telemetry"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+serde = "1.0.219"

--- a/telemetry/src/lib.rs
+++ b/telemetry/src/lib.rs
@@ -1,0 +1,11 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TelemetryRecord {
+    id: String,
+    timestamp: i64,
+    temperature: f32,
+    voltage: f32,
+    current: f32,
+    battery_level: i32,
+}


### PR DESCRIPTION
- Define `TelemetryRecord` with `Serialize` and `Deserialize`, meant to be used as (temporary?) master telemetry definition.
- To be used by `api` and `packetizer`.
- Meant to replace `TelemetryPacket` in `hdlc`.